### PR TITLE
fix build on arch

### DIFF
--- a/3rd/SDL/SConscript
+++ b/3rd/SDL/SConscript
@@ -53,6 +53,7 @@ elif OS_NAME == 'Linux':
 	    '/usr/include/pixman-1',
 	    '/usr/include/gdk-pixbuf-2.0',
 	    '/usr/include/glib-2.0',
+		'/usr/lib/glib-2.0/include',
 	    '/usr/lib/x86_64-linux-gnu/glib-2.0/include',
 	    '/usr/include/ibus-1.0',
 		'include',


### PR DESCRIPTION
fix build on arch
```
gcc -o 3rd/SDL/src/video/x11/SDL_x11window.o -c -g -Wall -DTK_ROOT=\"/tmp/ytmp/awtk-master\" -DWITH_STB_FONT -DSTBTT_STATIC -DSTB_IMAGE_STATIC -DWITH_STB_IMAGE -DWITH_VGCANVAS -DWITH_UNICODE_BREAK -DWITH_DESKTOP_STYLE -DSDL2 -DHAS_STD_MALLOC -DWITH_SDL -DWITH_FS_RES -DHAS_STDIO -DWITH_NANOVG_GPU -DWITH_VGCANVAS_LCD -DWITH_NANOVG_GL3 -DWITH_NANOVG_GL -DLINUX -DHAS_PTHREAD -DSDL_REAL_API -DSDL_TIMER_UNIX -DSDL_VIDEO_DRIVER_X11 -DSDL_VIDEO_DRIVER_X11_SUPPORTS_GENERIC_EVENTS -DSDL_AUDIO_DRIVER_SNDIO -DSDL_VIDEO_OPENGL_GLX -DSDL_VIDEO_RENDER_OGL -DSDL_LOADSO_DLOPEN -DSDL_VIDEO_OPENGL_EGL -DSDL_VIDEO_OPENGL_ES2 -DSDL_REAL_API -DSDL_HAPTIC_DISABLED -DSDL_SENSOR_DISABLED -DSDL_JOYSTICK_DISABLED -I/usr/include/gtk-3.0 -I/usr/include/dbus-1.0 -I/usr/lib/x86_64-linux-gnu/dbus-1.0/include -I/usr/include/gio-unix-2.0 -I/usr/include/pango-1.0 -I/usr/include/atk-1.0 -I/usr/include/cairo -I/usr/include/pixman-1 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/ibus-1.0 -I3rd/SDL/include -I3rd/SDL/gen -I3rd/SDL/src/video/khronos -I3rd/SDL/src 3rd/SDL/src/video/x11/SDL_x11window.c
In file included from /usr/include/glib-2.0/glib/galloca.h:32,
                 from /usr/include/glib-2.0/glib.h:30,
                 from /usr/include/gtk-3.0/gdk/gdkconfig.h:13,
                 from /usr/include/gtk-3.0/gdk/gdk.h:30,
                 from /usr/include/gtk-3.0/gtk/gtk.h:30,
                 from 3rd/SDL/src/video/x11/SDL_x11window.c:36:
/usr/include/glib-2.0/glib/gtypes.h:32:10: fatal error: glibconfig.h: No such file or directory
 #include <glibconfig.h>
          ^~~~~~~~~~~~~~
compilation terminated.
scons: *** [3rd/SDL/src/video/x11/SDL_x11window.o] Error 1
```