### PR TITLE
font_loader_ft: Load mono font if WITH_LCD_MONO defined

### DIFF
--- a/src/font_loader/font_loader_ft.c
+++ b/src/font_loader/font_loader_ft.c
@@ -181,7 +181,11 @@ font_t* font_ft_mono_create(const char* name, const uint8_t* buff, uint32_t size
 }
 
 font_t* font_ft_create(const char* name, const uint8_t* buff, uint32_t size) {
+#ifdef WITH_LCD_MONO
+  return font_ft_create_ex(name, buff, size, TRUE);
+#else
   return font_ft_create_ex(name, buff, size, FALSE);
+#endif
 }
 
 static font_t* font_ft_load(font_loader_t* loader, const char* name, const uint8_t* buff,


### PR DESCRIPTION
在MONO模式下，解析TTF字体需要设置mono标志，这样在使用FT_Load_Char的时候才能加上FT_LOAD_TARGET_MONO标志。