### PR TITLE
FIX:使用cairo时round_radius丢失的问题

### DIFF
--- a/src/vgcanvas/vgcanvas_cairo.c
+++ b/src/vgcanvas/vgcanvas_cairo.c
@@ -881,6 +881,7 @@ vgcanvas_t* vgcanvas_create(uint32_t w, uint32_t h, uint32_t stride, bitmap_form
   cairo->base.h = h;
   cairo->base.vt = &vt;
   cairo->base.ratio = 1;
+  cairo->base.stride = stride;
   cairo->base.format = format;
   cairo->base.buff = (uint32_t*)data;
 


### PR DESCRIPTION
应该是当时忘记写了，最终导致圆角信息并没有成功绘制