### PR TITLE
fix(typo): fix README demo project link

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -3,7 +3,7 @@
 ### 源文件和目录介绍
 
 * demo1\_app.c 演示按传统方式创建界面。
-* demo\_ui\_app.c 演示各种控件和动画效果(不适合作为编写代码参考，编写代码请参考：https://github.com/zlgopen/awtk-c-demos)。
+* demo\_ui\_app.c 演示各种控件和动画效果(不适合作为编写代码参考，编写代码请参考：<https://github.com/zlgopen/awtk-c-demos>)。
 * demo\_animator\_app.c 演示控件动画。 
 * demo\_desktop.c  演示开发桌面应用程序(使用原生输入法，可以调整窗口大小)。
 * demo\_thread\_app.c 演示非GUI线程操作GUI。


### PR DESCRIPTION
the original link will direct to a bad url because of the  "）。"