### PR TITLE
Fix deprecated distutils on python 3.12.

### DIFF
--- a/scripts/compile_config.py
+++ b/scripts/compile_config.py
@@ -5,7 +5,7 @@ import json
 import shutil
 import importlib
 import collections
-from distutils.util import strtobool
+from utils import strtobool
 
 global COMPILE_CONFIG
 COMPILE_CONFIG = None

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,0 +1,5 @@
+def strtobool(value: str) -> bool:
+  value = value.lower()
+  if value in ("y", "yes", "on", "1", "true", "t"):
+    return True
+  return False


### PR DESCRIPTION
https://docs.python.org/3.12/whatsnew/3.12.html
https://danielms.site/zet/2023/pythons-distutil-strtobool-replacement/

distutils is removed from python 3.12.
After I install latest `scons` from the `homebrew`, I found the `scons` is hosted on python 3.12, and the `distutils` package is missing.