### PR TITLE
fix memory leak

### DIFF
--- a/src/base/bidi.c
+++ b/src/base/bidi.c
@@ -97,6 +97,9 @@ bidi_t* bidi_init(bidi_t* bidi, bool_t alloc_l2v, bool_t alloc_v2l, bidi_type_t 
 }
 
 ret_t bidi_log2vis(bidi_t* bidi, const wchar_t* str, uint32_t size) {
+  return_value_if_fail(sizeof(wchar_t) == sizeof(FriBidiChar), RET_BAD_PARAMS);
+  return_value_if_fail(sizeof(uint32_t) == sizeof(FriBidiStrIndex), RET_BAD_PARAMS);
+
   FriBidiLevel level = 0;
   FriBidiParType type = FRIBIDI_PAR_ON;
   return_value_if_fail(bidi != NULL && str != NULL && size > 0, RET_BAD_PARAMS);
@@ -109,9 +112,6 @@ ret_t bidi_log2vis(bidi_t* bidi, const wchar_t* str, uint32_t size) {
     bidi->vis_str = TKMEM_ALLOC((size + 1) * sizeof(wchar_t));
   }
   return_value_if_fail(bidi->vis_str != NULL, RET_FAIL);
-
-  return_value_if_fail(sizeof(wchar_t) == sizeof(FriBidiChar), RET_BAD_PARAMS);
-  return_value_if_fail(sizeof(uint32_t) == sizeof(FriBidiStrIndex), RET_BAD_PARAMS);
 
   if (bidi->alloc_l2v) {
     bidi->positions_L_to_V = TKMEM_ZALLOCN(int32_t, size);

--- a/src/base/window_animator_factory.c
+++ b/src/base/window_animator_factory.c
@@ -122,7 +122,7 @@ static window_animator_t* window_animator_create_impl(const char* type, bool_t o
   return_value_if_fail(args != NULL && args->name[0], NULL);
 
   wa = window_animator_factory_create_animator(factory, open, args);
-  return_value_if_fail(wa != NULL, NULL);
+  goto_error_if_fail(wa != NULL);
 
   if (tk_object_get_prop(args, "duration", &v) == RET_OK) {
     wa->duration = value_int(&v);
@@ -135,7 +135,7 @@ static window_animator_t* window_animator_create_impl(const char* type, bool_t o
       wa->easing = easing_get((easing_type_t)(kv->value));
     }
   }
-
+error:
   tk_object_unref(args);
 
   return wa;

--- a/src/ext_widgets/mutable_image/mutable_image.c
+++ b/src/ext_widgets/mutable_image/mutable_image.c
@@ -48,6 +48,11 @@ static bitmap_t* mutable_image_prepare_image(widget_t* widget, canvas_t* c) {
   bitmap_format_t format = mutable_image_get_disire_format(widget, c);
   return_value_if_fail(mutable_image != NULL && mutable_image->prepare_image != NULL, NULL);
 
+  if (mutable_image->image != NULL) {
+    bitmap_destroy(mutable_image->image);
+    mutable_image->image = NULL;
+  }
+
   if (mutable_image->create_image != NULL) {
     void* ctx = mutable_image->create_image_ctx;
     mutable_image->image = mutable_image->create_image(ctx, format, mutable_image->image);
@@ -259,6 +264,11 @@ ret_t mutable_image_set_framebuffer(widget_t* widget, uint32_t w, uint32_t h,
                                     bitmap_format_t format, uint8_t* buff) {
   mutable_image_t* mutable_image = MUTABLE_IMAGE(widget);
   return_value_if_fail(mutable_image != NULL && buff != NULL, RET_BAD_PARAMS);
+
+  if (mutable_image->fb != NULL) {
+    bitmap_destroy(mutable_image->fb);
+    mutable_image->fb = NULL;
+  }
 
   mutable_image->fb = bitmap_create();
   return_value_if_fail(mutable_image->fb != NULL, RET_OOM);

--- a/src/hal/linux/network_interface_linux.c
+++ b/src/hal/linux/network_interface_linux.c
@@ -212,10 +212,10 @@ static int network_interface_linux_mobile_get_quality(network_interface_t* inter
 
 static void network_interface_linux_destroy(network_interface_t* interface) {
   network_interface_linux_t* linux_network_interface = (network_interface_linux_t*)interface;
-  TKMEM_FREE(interface->interface_name);
-  TKMEM_FREE(interface);
   if (linux_network_interface->ipaddr != NULL) TKMEM_FREE(linux_network_interface->ipaddr);
   if (linux_network_interface->macaddr != NULL) TKMEM_FREE(linux_network_interface->macaddr);
+  TKMEM_FREE(interface->interface_name);
+  TKMEM_FREE(interface);
 }
 
 static const network_interface_vtable_t s_linux_eth_vtable = {

--- a/src/native_window/native_window_raw.c
+++ b/src/native_window/native_window_raw.c
@@ -181,5 +181,9 @@ ret_t native_window_raw_init(lcd_t* lcd) {
 }
 
 ret_t native_window_raw_deinit(void) {
+  if (s_shared_win != NULL) {
+    tk_object_unref(TK_OBJECT(s_shared_win));
+    s_shared_win = NULL;
+  }
   return RET_OK;
 }

--- a/src/platforms/tos/thread.c
+++ b/src/platforms/tos/thread.c
@@ -104,6 +104,9 @@ tk_thread_t* tk_thread_create(tk_thread_entry_t entry, void* args) {
 ret_t tk_thread_start(tk_thread_t* thread) {
   return_value_if_fail(thread != NULL && !thread->running, RET_BAD_PARAMS);
 
+  if (thread->stackbase != NULL) {
+    TKMEM_FREE(thread->stackbase);
+  }
   thread->stackbase = TKMEM_ALLOC(thread->stack_size);
   return_value_if_fail(thread->stackbase != NULL, RET_OOM);
 

--- a/src/streams/inet/mbedtls_server.c
+++ b/src/streams/inet/mbedtls_server.c
@@ -18,6 +18,7 @@ static ret_t mbedtls_conn_server_destroy(mbedtls_conn_t* conn) {
   mbedtls_net_free(&(server_conn->client_fd));
   mbedtls_ssl_free(&(conn->ssl));
 
+  TKMEM_FREE(conn);
   return RET_OK;
 }
 
@@ -191,6 +192,7 @@ ret_t mbedtls_server_destroy(mbedtls_server_t* server) {
   mbedtls_ctr_drbg_free(&(server->ctr_drbg));
   mbedtls_entropy_free(&(server->entropy));
 
+  TKMEM_FREE(server);
   return RET_OK;
 }
 #endif /*WITH_MBEDTLS*/

--- a/src/tkc/date_time.c
+++ b/src/tkc/date_time.c
@@ -55,7 +55,12 @@ ret_t date_time_set_impl(date_time_get_now_t date_time_get_now) {
 date_time_t* date_time_create(void) {
   date_time_t* dt = TKMEM_ZALLOC(date_time_t);
 
-  return date_time_init(dt);
+  if (date_time_init(dt)) {
+    return dt;
+  } else {
+    TKMEM_FREE(dt);
+    return NULL;
+  }
 }
 
 ret_t date_time_from_time(date_time_t* dt, int64_t time) {


### PR DESCRIPTION
【原因分析】
1. src/src/streams/inet/mbedtls_client.c src/src/streams/inet/mbedtls_server.c mbedtls_server_accept函数申请内存创建mbedtls_conn_server_t对象 mbedtls_conn_client_create函数申请内存创建mbedtls_conn_client_t 二者使用虚函数表destroy成员，分别对应mbedtls_conn_server_destroy
和mbedtls_conn_client_destroy，进行销毁，但未释放内存

2. src/src/tkc/date_time.c 在date_time_create函数中，使用TKMEM_ZALLOC分配内存后
调用date_time_init(dt)，若date_time_init返回NULL
则分配的dt指针未被释放，导致内存泄漏

3. src/src/platforms/tos/thread.c
每次调用tk_thread_start都会为tk_thread_t::stackbase申请内存
但只有tk_thread_destroy时才会释放一次

4. src/src/base/window_animator_factory.c
在window_animator_create_impl函数中，若
window_animator_factory_create_animator返回NULL，
则未执行tk_object_unref(args)，导致func_call_parse分配
的args对象内存泄漏。

5. src/src/ext_widgets/mutable_image/mutable_image.c 调用mutable_image_set_framebuffer或mutable_image_prepare_image 函数时，mutable_image->fb和mutable_image->image未释放导致内存泄漏

6. src/src/hal/linux/network_interface_linux.c network_interface_linux_destroy中先释放linux_network_interface 再释放linux_network_interface->ipaddr/macaddr
访问了释放后的指针，多线程下存在崩溃风险

7. src/src/base/bidi.c bidi_log2vis函数分配 vis_str 后，如果后续失败导致函数提前返回，
未释放 vis_str，导致内存泄漏。

8. src/src/ext_widgets/rich_text/rich_text_parser.c 8.1. builder_init函数中，每个fonts数组元素的name字段通过
            tk_strdup(font_name)分配内存且xml_rich_text_destroy
                中未释放
8.2. fonts数组每个元素分配了name字段但font_level还是0，
            导致xml_rich_text_push_font时b->font->name覆盖原本
                的字符串指针且未释放原指针

9.  src/src/native_window/native_window_raw.c native_window_raw_deinit未实现导致内存泄漏

【修改内容】
1. destroy函数中补充内存释放
2. date_time_init返回NULL则释放内存
3. 每次调用tk_thread_start时释放内存
4. 函数window_animator_factory_create_animator创建失败则释放args
5. 分配前先释放mutable_image->fb和mutable_image->image
6. 最后释放linux_network_interface
7. 失败检查返回的逻辑放在分配内存之前
8. 初始时font_level为0，只为fonts数组元素0设置name xml_rich_text_destroy释放fonts数组所有的name指针
9. 参考native_window_fb_gl_deinit实现